### PR TITLE
feat(alerting): bridge Alertmanager to OpenClaw hooks

### DIFF
--- a/manifests/openclaw/networkpolicy.yaml
+++ b/manifests/openclaw/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openclaw-ingress
+  namespace: openclaw
+spec:
+  podSelector:
+    matchLabels:
+      app: openclaw
+  policyTypes:
+    - Ingress
+  ingress:
+    # Keep existing public/UI path behavior via oauth2-proxy service on port 4180.
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 4180
+    # Restrict direct Gateway API ingress (hooks bridge) to monitoring namespace.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 18789

--- a/manifests/openclaw/networkpolicy.yaml
+++ b/manifests/openclaw/networkpolicy.yaml
@@ -16,11 +16,15 @@ spec:
       ports:
         - protocol: TCP
           port: 4180
-    # Restrict direct Gateway API ingress (hooks bridge) to monitoring namespace.
+    # Restrict direct Gateway API ingress (hooks bridge) to Alertmanager pods only.
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmalertmanager
+              app.kubernetes.io/instance: vmalertmanager
       ports:
         - protocol: TCP
           port: 18789

--- a/manifests/openclaw/service-gateway-internal.yaml
+++ b/manifests/openclaw/service-gateway-internal.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw-gateway-internal
+  namespace: openclaw
+  labels:
+    app: openclaw
+spec:
+  type: ClusterIP
+  selector:
+    app: openclaw
+  ports:
+    - name: gateway
+      port: 18789
+      targetPort: 18789
+      protocol: TCP

--- a/manifests/victoria-metrics/externalsecret-alertmanager.yaml
+++ b/manifests/victoria-metrics/externalsecret-alertmanager.yaml
@@ -25,20 +25,47 @@ spec:
             group_interval: 10s
             repeat_interval: 4h
 
+          inhibit_rules:
+            - source_matchers:
+                - severity="critical"
+              target_matchers:
+                - severity=~"warning|info"
+              equal:
+                - alertname
+                - namespace
+                - pod
+                - instance
+                - node
+
           receivers:
             - name: telegram
               telegram_configs:
-                - bot_token: "{{ .bot_token }}"
+                - send_resolved: true
+                  bot_token: "{{ .bot_token }}"
                   chat_id: {{ .chat_id }}
                   parse_mode: HTML
+                  disable_web_page_preview: true
                   message: |-
                     {{ "{{" }} range .Alerts {{ "}}" }}
-                    {{ "{{" }} if eq .Status "resolved" {{ "}}" }}✅{{ "{{" }} else {{ "}}" }}🔥{{ "{{" }} end {{ "}}" }} <b>{{ "{{" }} .Labels.alertname {{ "}}" }}</b> [{{ "{{" }} .Status | toUpper {{ "}}" }}]
-                    {{ "{{" }} .Annotations.summary {{ "}}" }}
+                    {{ "{{" }} if eq .Status "resolved" {{ "}}" }}✅{{ "{{" }} else if eq .Labels.severity "critical" {{ "}}" }}🚨{{ "{{" }} else {{ "}}" }}🔥{{ "{{" }} end {{ "}}" }} <b>{{ "{{" }} .Labels.alertname {{ "}}" }}</b> [{{ "{{" }} .Status | toUpper {{ "}}" }}]
+                    {{ "{{" }} if .Labels.severity {{ "}}" }}<b>Severity:</b> {{ "{{" }} .Labels.severity {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Labels.namespace {{ "}}" }}<b>Namespace:</b> {{ "{{" }} .Labels.namespace {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Labels.pod {{ "}}" }}<b>Pod:</b> {{ "{{" }} .Labels.pod {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Labels.node {{ "}}" }}<b>Node:</b> {{ "{{" }} .Labels.node {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Labels.nodename {{ "}}" }}<b>Nodename:</b> {{ "{{" }} .Labels.nodename {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Labels.instance {{ "}}" }}<b>Instance:</b> {{ "{{" }} .Labels.instance {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Annotations.summary {{ "}}" }}<b>Summary:</b> {{ "{{" }} .Annotations.summary {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Annotations.description {{ "}}" }}<b>Description:</b> {{ "{{" }} .Annotations.description {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    <b>Started:</b> {{ "{{" }} .StartsAt {{ "}}" }}
+                    {{ "{{" }} if eq .Status "resolved" {{ "}}" }}<b>Resolved:</b> {{ "{{" }} .EndsAt {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .GeneratorURL {{ "}}" }}<b>Source:</b> {{ "{{" }} .GeneratorURL {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+                    {{ "{{" }} if .Fingerprint {{ "}}" }}<code>{{ "{{" }} .Fingerprint {{ "}}" }}</code>{{ "{{" }} end {{ "}}" }}
+
                     {{ "{{" }} end {{ "}}" }}
               webhook_configs:
                 - url: http://openclaw-gateway-internal.openclaw.svc.cluster.local:18789/hooks/alertmanager
                   send_resolved: true
+                  max_alerts: 25
                   http_config:
                     authorization:
                       type: Bearer

--- a/manifests/victoria-metrics/externalsecret-alertmanager.yaml
+++ b/manifests/victoria-metrics/externalsecret-alertmanager.yaml
@@ -36,6 +36,13 @@ spec:
                     {{ "{{" }} if eq .Status "resolved" {{ "}}" }}✅{{ "{{" }} else {{ "}}" }}🔥{{ "{{" }} end {{ "}}" }} <b>{{ "{{" }} .Labels.alertname {{ "}}" }}</b> [{{ "{{" }} .Status | toUpper {{ "}}" }}]
                     {{ "{{" }} .Annotations.summary {{ "}}" }}
                     {{ "{{" }} end {{ "}}" }}
+              webhook_configs:
+                - url: http://openclaw-gateway-internal.openclaw.svc.cluster.local:18789/hooks/alertmanager
+                  send_resolved: true
+                  http_config:
+                    authorization:
+                      type: Bearer
+                      credentials: "{{ .openclaw_hook_token }}"
   data:
     - secretKey: bot_token
       remoteRef:
@@ -45,3 +52,7 @@ spec:
       remoteRef:
         key: secret/data/alertmanager/telegram
         property: chat_id
+    - secretKey: openclaw_hook_token
+      remoteRef:
+        key: secret/data/alertmanager/openclaw
+        property: hooks_token


### PR DESCRIPTION
## Summary
- add internal service `openclaw-gateway-internal` in `openclaw` namespace (port `18789`) for in-cluster hook ingress
- add `NetworkPolicy` for `app=openclaw`:
  - keep existing ingress on `4180` open across namespaces (oauth2-proxy/UI path)
  - allow direct gateway ingress on `18789` only from `monitoring` namespace
- extend Alertmanager config template to send webhook notifications to:
  - `http://openclaw-gateway-internal.openclaw.svc.cluster.local:18789/hooks/alertmanager`
  - with Bearer auth from ExternalSecret key `openclaw_hook_token`

## Secret wiring
This PR expects a Vault/OpenBao secret for Alertmanager webhook auth:
- `secret/data/alertmanager/openclaw`
- property: `hooks_token`

## Notes
- Telegram receiver behavior is preserved; webhook delivery is added alongside current telegram config.
- OpenClaw still needs `hooks` mapping for `path=alertmanager` configured in its runtime config to consume this payload as agent input.
