### PR TITLE
feat(cloudflare-tunnel): switch to v2.0.4 with in-process proxy mode

### DIFF
--- a/argocd/infra/cloudflare-tunnel-gateway-controller.yaml
+++ b/argocd/infra/cloudflare-tunnel-gateway-controller.yaml
@@ -14,7 +14,7 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/lexfrei/charts/cloudflare-tunnel-gateway-controller
     - chart: cloudflare-tunnel-gateway-controller
       repoURL: ghcr.io/lexfrei/charts
-      targetRevision: 2.0.2
+      targetRevision: 2.0.4
       helm:
         valuesObject:
           gatewayClassConfig:
@@ -25,8 +25,11 @@ spec:
             tunnelTokenSecretRef:
               name: "cloudflare-tunnel-token"
             cloudflared:
-              enabled: true
-              replicas: 1
+              enabled: false
+          proxy:
+            enabled: true
+            tunnelTokenSecretRef:
+              name: "cloudflare-tunnel-token"
     - path: manifests/cloudflare-tunnel-gateway-controller
       repoURL: https://github.com/lexfrei/k8s.git
       targetRevision: HEAD


### PR DESCRIPTION
## Summary

Test the cloudflare-tunnel-gateway-controller v2 proxy mode on homelab. The proxy runs cloudflared as an in-process tunnel transport and routes ALL incoming traffic through an L7 HTTP router, which is what enables full Gateway API support (wildcards, complex matching, filters, weighted backends) independently of cloudflared's limited native ingress-rule schema.

## Changes

- Bump chart `2.0.2` → `2.0.4`
- `gatewayClassConfig.cloudflared.enabled: true → false` — disable the helm-managed sidecar cloudflared deployment so the proxy is the only tunnel client. Without this both connect to the same tunnel and Cloudflare load-balances requests between them, producing half-and-half routing behaviour.
- Add `proxy` section pointing at the existing `cloudflare-tunnel-token` Secret.

## Notes

- Reversible: `git revert` this commit + push → ArgoCD rolls back.
- Existing HTTPRoutes will be programmed through the proxy after sync.
- During the rollout there may be a few seconds of disruption as the helm-managed cloudflared is uninstalled before the proxy registers.