### PR TITLE
fix(cloudflare-tunnel): set clusterDomain to k8s.home.lex.la

### DIFF
--- a/argocd/infra/cloudflare-tunnel-gateway-controller.yaml
+++ b/argocd/infra/cloudflare-tunnel-gateway-controller.yaml
@@ -17,6 +17,8 @@ spec:
       targetRevision: 2.0.4
       helm:
         valuesObject:
+          controller:
+            clusterDomain: "k8s.home.lex.la"
           gatewayClassConfig:
             create: true
             tunnelID: "59db961d-3851-468a-bf80-4d39f942b9e0"


### PR DESCRIPTION
## Summary

After deploying v2.0.4 with proxy mode, the controller cannot push routing config to the proxy headless service. Logs show:

```
no such host: cloudflare-tunnel-gateway-controller-proxy-headless.cloudflare-tunnel-system.svc.cluster.local
```

The chart's `--proxy-endpoints` template falls back to `.svc.cluster.local` when `controller.clusterDomain` is empty. Homelab uses `k8s.home.lex.la` (CoreDNS `kubernetes k8s.home.lex.la in-addr.arpa ip6.arpa`). Auto-detection at controller runtime works for cloudflared API config (which uses the right domain), but the helm-rendered CLI flag is built at install-time and the value is empty.

## Changes

- Add `controller.clusterDomain: k8s.home.lex.la` to homelab values