### PR TITLE
chore(gateway-api-crds): bump to v1.5.1

### DIFF
--- a/argocd/infra/gateway-api-crds.yaml
+++ b/argocd/infra/gateway-api-crds.yaml
@@ -13,7 +13,7 @@ spec:
   source:
     repoURL: "https://github.com/kubernetes-sigs/gateway-api.git"
     # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-    targetRevision: "v1.4.1"
+    targetRevision: "v1.5.1"
     path: "config/crd/standard"
   syncPolicy:
     automated:


### PR DESCRIPTION
Latest stable. Required for the official Gateway API conformance suite v1.5 (strict CRD bundle version check). v1 API surface is stable, bump is additive.