### PR TITLE
feat(grafana): add GitHub CI datasource for workflow metrics

### DIFF
--- a/manifests/grafana/external-secret.yaml
+++ b/manifests/grafana/external-secret.yaml
@@ -24,3 +24,7 @@ spec:
       remoteRef:
         key: secret/data/grafana/oidc
         property: client_secret
+    - secretKey: GITHUB_TOKEN
+      remoteRef:
+        key: secret/data/grafana/github
+        property: token

--- a/manifests/grafana/github-datasource.yaml
+++ b/manifests/grafana/github-datasource.yaml
@@ -1,0 +1,27 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: github-datasource
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  # grafana-operator installs the plugin into the Grafana deployment from this list.
+  plugins:
+    - name: grafana-github-datasource
+      version: "2.8.0"
+  # Token is injected from the ESO-managed Secret, not stored in git.
+  valuesFrom:
+    - targetPath: "secureJsonData.accessToken"
+      valueFrom:
+        secretKeyRef:
+          name: grafana-credentials
+          key: GITHUB_TOKEN
+  datasource:
+    name: GitHub
+    type: grafana-github-datasource
+    access: proxy
+    jsonData:
+      selectedAuthType: personal-access-token
+    secureJsonData:
+      accessToken: "${GITHUB_TOKEN}"


### PR DESCRIPTION
Provision the `grafana-github-datasource` plugin (v2.8.0) and a GitHub datasource via grafana-operator. Access token comes from the ESO-managed `grafana-credentials` secret (OpenBao key `secret/grafana/github`), not git.

Enables Grafana dashboards over GitHub Actions workflow runs (initial target: cozystack/cozystack CI health).